### PR TITLE
unit-test: also test stream-based query function

### DIFF
--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-12]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -17,7 +17,7 @@ main = do
       port <- maybe (fail $ "invalid port number: " <> portStr) pure (readMaybe portStr)
       pure (port, graphDataFileName)
     _ -> fail "Expected exactly two arguments: (1) port number; (2) graph JSON data filename"
-  Server.main Server.defaultSearchConfig{Server.searchConfigTrace = True} appendToHead port graphDataFileName
+  Server.main Server.defaultSearchConfig appendToHead port graphDataFileName
   where
     appendToHead = style_ $ TE.decodeUtf8 cssBS
     cssBS = $(Data.FileEmbed.makeRelativeToProject "css/chota.css" >>= Data.FileEmbed.embedFile)

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -17,7 +17,7 @@ main = do
       port <- maybe (fail $ "invalid port number: " <> portStr) pure (readMaybe portStr)
       pure (port, graphDataFileName)
     _ -> fail "Expected exactly two arguments: (1) port number; (2) graph JSON data filename"
-  Server.main Server.defaultSearchConfig appendToHead port graphDataFileName
+  Server.main Server.defaultSearchConfig{Server.searchConfigTrace = True} appendToHead port graphDataFileName
   where
     appendToHead = style_ $ TE.decodeUtf8 cssBS
     cssBS = $(Data.FileEmbed.makeRelativeToProject "css/chota.css" >>= Data.FileEmbed.embedFile)

--- a/benchmark/lib/BenchmarkLib.hs
+++ b/benchmark/lib/BenchmarkLib.hs
@@ -4,8 +4,9 @@ import Criterion.Main
 import qualified FunGraph
 import qualified FunGraph.Test
 import qualified Control.Monad.ST as ST
-import Data.Functor (void)
+import Data.Functor (void, (<&>))
 import Control.Monad ((<=<))
+import qualified Data.List.NonEmpty as NE
 
 testDataFileName :: FilePath
 testDataFileName = "data/all3.json"
@@ -22,16 +23,17 @@ main = do
       , bench "Thaw" $ nfAppIO (void . ST.stToIO . FunGraph.thaw) frozenGraph
       , bench "Thaw+freeze" $ nfAppIO (void . ST.stToIO . (FunGraph.freeze <=< FunGraph.thaw)) frozenGraph
       ]
-    , bgroup "Query"
-      [ bgroup "queryPaths" $
-          map (queryPaths mutGraph) FunGraph.Test.allTestCases
-      ]
+    , bgroup "Query" $
+        map (queryPaths mutGraph) FunGraph.Test.allTestCases
     ]
   where
     queryPaths mutGraph test =
-      let (maxCount, _) = FunGraph.Test.queryTest_args test
-      in bench (FunGraph.Test.queryTest_name test <> " maxCount=" <> show maxCount) $
-        nfAppIO (\g -> ST.stToIO $ FunGraph.runGraphAction g $ FunGraph.Test.queryTest_runQuery test) mutGraph
+      let args@(maxCount, _) = FunGraph.Test.queryTest_args test
+          blahName = FunGraph.Test.queryTest_name test <> " maxCount=" <> show maxCount
+      in bgroup blahName $ NE.toList $
+        FunGraph.Test.mkQueryFunctions False <&> \(queryFunctionName, queryFunction) ->
+          bench queryFunctionName $
+            nfAppIO (queryFunction args) mutGraph
 
     readGraphData fileName =
       either fail pure =<< FunGraph.fileReadDeclarationMap fileName

--- a/benchmark/lib/BenchmarkLib.hs
+++ b/benchmark/lib/BenchmarkLib.hs
@@ -1,5 +1,6 @@
-module Main where
-
+module Main
+(main)
+where
 import Criterion.Main
 import qualified FunGraph
 import qualified FunGraph.Test
@@ -7,13 +8,11 @@ import qualified Control.Monad.ST as ST
 import Data.Functor (void, (<&>))
 import Control.Monad ((<=<))
 import qualified Data.List.NonEmpty as NE
-
-testDataFileName :: FilePath
-testDataFileName = "data/all3.json"
+import qualified FunGraph.Test.Util
 
 main :: IO ()
 main = do
-  graphData <- readGraphData testDataFileName
+  graphData <- readGraphData FunGraph.Test.Util.testDataFileName
   mutGraph <- ST.stToIO $ FunGraph.buildGraphMut FunGraph.defaultBuildConfig graphData
   frozenGraph <- ST.stToIO $ buildGraphFreeze graphData
   defaultMain
@@ -29,8 +28,8 @@ main = do
   where
     queryPaths mutGraph test =
       let args@(maxCount, _) = FunGraph.Test.queryTest_args test
-          blahName = FunGraph.Test.queryTest_name test <> " maxCount=" <> show maxCount
-      in bgroup blahName $ NE.toList $
+          nameWithMaxCount = FunGraph.Test.queryTest_name test <> " maxCount=" <> show maxCount
+      in bgroup nameWithMaxCount $ NE.toList $
         FunGraph.Test.mkQueryFunctions False <&> \(queryFunctionName, queryFunction) ->
           bench queryFunctionName $
             nfAppIO (queryFunction args) mutGraph

--- a/benchmark/web/BenchmarkWeb.hs
+++ b/benchmark/web/BenchmarkWeb.hs
@@ -26,9 +26,6 @@ import Control.Monad (when)
 import Data.Maybe (isJust)
 import qualified Data.ByteString.Lazy as BSL
 
-testDataFileName :: FilePath
-testDataFileName = "data/all3.json"
-
 -- NOTE: If a benchmark times out then increase this limit
 searchConfig :: Server.Pages.Search.SearchConfig
 searchConfig = Server.Pages.Search.defaultSearchConfig
@@ -37,7 +34,7 @@ searchConfig = Server.Pages.Search.defaultSearchConfig
 
 main :: IO ()
 main =
-  Server.withHandlers logger searchConfig mempty testDataFileName $ \handlers ->
+  Server.withHandlers logger searchConfig mempty FunGraph.Test.Util.testDataFileName $ \handlers ->
     runWarpTestRandomPort (Server.app handlers) $ \port ->
       mkQueryFunction port >>= runTests
   where

--- a/default.nix
+++ b/default.nix
@@ -30,6 +30,7 @@ let
       servant-errors = servant-errors;
     };
 
+  # TODO: run 'test-web' executable as part of build and fail build on non-zero exit code
   function-graph = nixpkgs.pkgs.haskell.lib.doBenchmark (
     nixpkgs.pkgs.haskell.packages.${compiler}.callCabal2nix "function-graph" ./. args
   );

--- a/function-graph.cabal
+++ b/function-graph.cabal
@@ -210,4 +210,6 @@ executable test-web
     , async
     , streaming
     , html-parse
+    , ansi-terminal
+    , temporary
   default-language: Haskell2010

--- a/function-graph.cabal
+++ b/function-graph.cabal
@@ -106,6 +106,8 @@ library test
                     , wai
                     , async
                     , streaming
+                    , transformers
+                    , time
     hs-source-dirs:   src/test
     default-language: Haskell2010
 

--- a/src/lib/FunGraph.hs
+++ b/src/lib/FunGraph.hs
@@ -15,7 +15,7 @@
 --   TODO: Prioritize functions from _existing_ dependencies. Ie. take a list of dependencies for which functions are prioritized higher.
 module FunGraph
   ( -- * Queries
-    queryPathsGA, queryTreeGA, queryTreeAndPathsGA, queryTreeAndPathsGAStream
+    queryPathsGA, queryTreeGA, queryTreeAndPathsGA
   , queryTreeTimeoutIO, queryTreeTimeoutIOTrace
   , GraphAction, runGraphAction, runGraphActionTrace, GraphActionError(..)
     -- * Conversions
@@ -103,24 +103,6 @@ queryTreeAndPathsGA
 queryTreeAndPathsGA maxCount srcDst =
   queryTreeGA maxCount srcDst <&> \tree ->
       (tree, queryResultTreeToPaths maxCount srcDst tree)
-
-queryTreeAndPathsGAStream
-  :: ( v ~ FullyQualifiedType
-     )
-  => DG.Digraph RealWorld FullyQualifiedType (NE.NonEmpty TypedFunction)
-  -> Data.Time.NominalDiffTime -- ^ timeout
-  -> Int -- ^ max count
-  -> (v, v) -- ^ (src, dst)
-  -> ExceptT (GraphActionError v) IO
-      (S.Stream
-        (S.Of (([NE.NonEmpty TypedFunction], Double), [([TypedFunction], Double)]))
-        IO
-        (Maybe ())
-      )
-queryTreeAndPathsGAStream graph timeout maxCount srcDst =
-  let blah tree =
-        (tree, queryResultTreeToPaths maxCount srcDst [tree])
-  in S.map blah <$> queryTreeTimeoutIO graph timeout maxCount srcDst
 
 queryPathsGA
   :: ( v ~ FullyQualifiedType

--- a/src/lib/FunGraph.hs
+++ b/src/lib/FunGraph.hs
@@ -61,7 +61,6 @@ import qualified Streaming as S
 import qualified Control.Monad.ST as ST
 import qualified Streaming.Prelude as S
 import qualified Streaming.Prelude.Extras
-import qualified GHC.IO.Unsafe
 
 -- | Convert a shortest path tree into a list of shortests paths.
 --
@@ -172,7 +171,7 @@ queryTreeTimeoutIOTrace
   :: ( v ~ FullyQualifiedType
      , meta ~ NE.NonEmpty TypedFunction
      )
-  => (String -> ST RealWorld ())
+  => (String -> ST RealWorld ()) -- ^ Trace function
   -> DG.Digraph RealWorld v meta
   -> Data.Time.NominalDiffTime
   -> Int
@@ -288,7 +287,7 @@ queryTreeGA maxCount (src, dst) =
           minimum $ map (functionWeight (src, dst)) (NE.toList functions)
 
 traceFunDebugGeneric
-  :: (String -> ST s ())
+  :: (String -> ST s ()) -- ^ Trace function
   -> Dijkstra.TraceEvent FullyQualifiedType (NE.NonEmpty TypedFunction) Double
   -> ST s ()
 traceFunDebugGeneric traceFun = \case

--- a/src/lib/FunGraph.hs
+++ b/src/lib/FunGraph.hs
@@ -15,7 +15,7 @@
 --   TODO: Prioritize functions from _existing_ dependencies. Ie. take a list of dependencies for which functions are prioritized higher.
 module FunGraph
   ( -- * Queries
-    queryPathsGA, queryTreeGA, queryTreeAndPathsGA
+    queryPathsGA, queryTreeGA, queryTreeAndPathsGA, queryTreeAndPathsGAStream
   , queryTreeTimeoutIO, queryTreeTimeoutIOTrace
   , GraphAction, runGraphAction, runGraphActionTrace, GraphActionError(..)
     -- * Conversions
@@ -103,6 +103,24 @@ queryTreeAndPathsGA
 queryTreeAndPathsGA maxCount srcDst =
   queryTreeGA maxCount srcDst <&> \tree ->
       (tree, queryResultTreeToPaths maxCount srcDst tree)
+
+queryTreeAndPathsGAStream
+  :: ( v ~ FullyQualifiedType
+     )
+  => DG.Digraph RealWorld FullyQualifiedType (NE.NonEmpty TypedFunction)
+  -> Data.Time.NominalDiffTime -- ^ timeout
+  -> Int -- ^ max count
+  -> (v, v) -- ^ (src, dst)
+  -> ExceptT (GraphActionError v) IO
+      (S.Stream
+        (S.Of (([NE.NonEmpty TypedFunction], Double), [([TypedFunction], Double)]))
+        IO
+        (Maybe ())
+      )
+queryTreeAndPathsGAStream graph timeout maxCount srcDst =
+  let blah tree =
+        (tree, queryResultTreeToPaths maxCount srcDst [tree])
+  in S.map blah <$> queryTreeTimeoutIO graph timeout maxCount srcDst
 
 queryPathsGA
   :: ( v ~ FullyQualifiedType

--- a/src/server/Server.hs
+++ b/src/server/Server.hs
@@ -6,7 +6,7 @@ module Server
   ( main
   , app
   , withHandlers
-  , Server.Pages.Search.defaultSearchConfig
+  , Server.Pages.Search.defaultSearchConfig, Server.Pages.Search.SearchConfig(..)
   )
   where
 

--- a/src/server/Server/Pages/Search.hs
+++ b/src/server/Server/Pages/Search.hs
@@ -40,6 +40,7 @@ import qualified Streaming.Prelude as S
 import qualified Data.BalancedStream
 import Control.Monad (when)
 import qualified Data.Time.Clock
+import qualified Control.Monad.ST
 
 -- | Things we want to precompute when creating the handler
 data SearchEnv = SearchEnv
@@ -50,14 +51,14 @@ data SearchEnv = SearchEnv
 -- | TODO
 data SearchConfig = SearchConfig
   { searchConfigTimeout :: !Data.Time.Clock.NominalDiffTime
-  , searchConfigTrace :: !Bool
-  -- ^ Make the server print tracing information for each search query
+  , searchConfigTrace :: !(Maybe (String -> Control.Monad.ST.ST Control.Monad.ST.RealWorld ()))
+  -- ^ Optionally print tracing information for each search query
   }
 
 defaultSearchConfig :: SearchConfig
 defaultSearchConfig = SearchConfig
   { searchConfigTimeout = 0.1
-  , searchConfigTrace = False
+  , searchConfigTrace = Nothing
   }
 
 createSearchEnv
@@ -227,9 +228,10 @@ page cfg (SearchEnv graph lookupVertex) srcTxt dstTxt maxCount' mNoGraph = do
         (lookupVertex txt)
 
     queryTreeTimeoutIO =
-      if searchConfigTrace cfg
-        then FunGraph.queryTreeTimeoutIOTrace
-        else FunGraph.queryTreeTimeoutIO
+      maybe
+        FunGraph.queryTreeTimeoutIO
+        FunGraph.queryTreeTimeoutIOTrace
+        (searchConfigTrace cfg)
 
     query' srcDst =
       ET.runExceptT $

--- a/src/server/Server/Pages/Search.hs
+++ b/src/server/Server/Pages/Search.hs
@@ -50,11 +50,14 @@ data SearchEnv = SearchEnv
 -- | TODO
 data SearchConfig = SearchConfig
   { searchConfigTimeout :: !Data.Time.Clock.NominalDiffTime
+  , searchConfigTrace :: !Bool
+  -- ^ Make the server print tracing information for each search query
   }
 
 defaultSearchConfig :: SearchConfig
 defaultSearchConfig = SearchConfig
   { searchConfigTimeout = 0.1
+  , searchConfigTrace = False
   }
 
 createSearchEnv
@@ -223,9 +226,14 @@ page cfg (SearchEnv graph lookupVertex) srcTxt dstTxt maxCount' mNoGraph = do
         pure
         (lookupVertex txt)
 
+    queryTreeTimeoutIO =
+      if searchConfigTrace cfg
+        then FunGraph.queryTreeTimeoutIOTrace
+        else FunGraph.queryTreeTimeoutIO
+
     query' srcDst =
       ET.runExceptT $
-          FunGraph.queryTreeTimeoutIO
+          queryTreeTimeoutIO
             graph
             timeout
             maxCount

--- a/src/test/FunGraph/Test.hs
+++ b/src/test/FunGraph/Test.hs
@@ -10,7 +10,7 @@ module FunGraph.Test
 , QueryTest(..), queryTest_runQuery, Args
 , PPFunctions(..)
   -- * TODO
-, queryTreeAndPathsGAStreamTest
+, queryTreeAndPathsGAStreamTest, queryTest_runQueryFun_todo
 )
 where
 
@@ -49,6 +49,14 @@ queryTest_runQuery
   -> FunGraph.GraphAction s FunGraph.FullyQualifiedType (NE.NonEmpty FunGraph.TypedFunction) [(PPFunctions, Double)]
 queryTest_runQuery qt =
   queryTest_runQueryFun qt (queryTest_args qt)
+
+queryTest_runQueryFun_todo
+  :: Args
+  -> FunGraph.GraphAction s FunGraph.FullyQualifiedType (NE.NonEmpty FunGraph.TypedFunction) [(PPFunctions, Double)]
+queryTest_runQueryFun_todo args =
+  mapQueryResult . snd <$> uncurry FunGraph.queryTreeAndPathsGA args
+  where
+    mapQueryResult = map (first $ PPFunctions . map void)
 
 mkTestCase
   :: Int

--- a/src/test/FunGraph/Test.hs
+++ b/src/test/FunGraph/Test.hs
@@ -7,7 +7,7 @@
 {-# HLINT ignore "Use fmap" #-}
 module FunGraph.Test
 ( allTestCases
-, QueryTest(..), queryTest_runQuery
+, QueryTest(..), queryTest_runQuery, Args
 , PPFunctions(..)
   -- * TODO
 , queryTreeAndPathsGAStreamTest

--- a/src/test/FunGraph/Test.hs
+++ b/src/test/FunGraph/Test.hs
@@ -41,6 +41,7 @@ data QueryTest = QueryTest
 
 type Args = (Int, (FunGraph.FullyQualifiedType, FunGraph.FullyQualifiedType)) -- ^ (maxCount, (src, dst))
 
+-- | Test 'FunGraph.queryTreeAndPathsGA'
 queryTreeAndPathsGAListTest
   :: Args
   -> FunGraph.GraphAction s FunGraph.FullyQualifiedType (NE.NonEmpty FunGraph.TypedFunction) [(PPFunctions, Double)]
@@ -70,6 +71,7 @@ mkTestCase maxCount (from, to) expectedList =
       id
       (FunGraph.parseComposedFunctions bs)
 
+-- | Test 'FunGraph.queryTreeTimeoutIO'
 queryTreeAndPathsGAStreamTest
   :: ( v ~ FunGraph.FullyQualifiedType
      )

--- a/src/test/FunGraph/Test.hs
+++ b/src/test/FunGraph/Test.hs
@@ -143,7 +143,7 @@ case3 =
 
 case4 :: QueryTest
 case4 =
-  mkTestCase 100
+  mkTestCase 45
     (strictByteString, lazyText)
     [ "text-2.0.2:Data.Text.Lazy.pack . bytestring-0.11.4.0:Data.ByteString.Char8.unpack"
     , "text-2.0.2:Data.Text.Lazy.fromStrict . text-2.0.2:Data.Text.Encoding.decodeASCII"

--- a/src/test/FunGraph/Test/Util.hs
+++ b/src/test/FunGraph/Test/Util.hs
@@ -10,6 +10,7 @@ module FunGraph.Test.Util
 , runWarpTestRandomPort
 , isSupersetOf
 , StreamIOHtml
+, testDataFileName
 )
 where
 
@@ -39,6 +40,9 @@ import Servant.HTML.Lucid (HTML)
 import Server.HtmlStream (HtmlStream, toStream)
 import Test.Hspec.Expectations.Pretty (shouldBe)
 import Lucid.Base (Html)
+
+testDataFileName :: FilePath
+testDataFileName = "data/all3.json"
 
 isSupersetOf :: (Show a, Ord a) => Set.Set a -> Set.Set a -> IO ()
 isSupersetOf actual expected =

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -32,10 +32,9 @@ main =
       runHspecWithTraceTip shouldTrace spec
   where
     mkQueryFunctions shouldTrace = NE.fromList
-      [ ("Stream", queryTestStream)
+      [ ("Stream", FunGraph.Test.queryTreeAndPathsGAStreamTest 1000)
       , ("List", mkQueryTestList shouldTrace)
       ]
-      -- TODO: list-based query function
 
     mkQueryTestList
       :: Bool
@@ -45,16 +44,7 @@ main =
     mkQueryTestList shouldTrace args graph =
       let runQueryFunction =
             if shouldTrace then FunGraph.runGraphActionTrace else FunGraph.runGraphAction
-      in ST.stToIO $ runQueryFunction graph $ FunGraph.Test.queryTest_runQueryFun_todo args
-
-    queryTestStream
-      :: FunGraph.Test.Args
-      -> FunGraph.Graph ST.RealWorld
-      -> IO QueryResults
-    queryTestStream =
-      FunGraph.Test.queryTreeAndPathsGAStreamTest timeout
-      where
-        timeout = 1000
+      in ST.stToIO $ runQueryFunction graph $ FunGraph.Test.queryTreeAndPathsGAListTest args
 
     traceCLIArg :: String
     traceCLIArg = "--trace"

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -21,13 +21,10 @@ import qualified Data.Graph.Digraph as DG
 import qualified Data.List.NonEmpty as NE
 import Data.Functor (void)
 
-testDataFileName :: FilePath
-testDataFileName = "data/all3.json"
-
 main :: IO ()
 main =
   withTraceArg $ \shouldTrace ->
-    FunGraph.withGraphFromFile FunGraph.defaultBuildConfig testDataFileName $ \graph -> do
+    FunGraph.withGraphFromFile FunGraph.defaultBuildConfig FunGraph.Test.Util.testDataFileName $ \graph -> do
       spec <- main' shouldTrace (FunGraph.Test.mkQueryFunctions shouldTrace) graph
       runHspecWithTraceTip shouldTrace spec
   where

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -101,8 +101,7 @@ main' shouldTrace queryFunctions graph = do
                     FunGraph.Test.queryTest_expectedResult test
   pure $ HSpec.describe "Unit tests" $ do
     HSpec.describe "Expected result" $
-      HSpec.describe "Stream" $
-        forM_ FunGraph.Test.allTestCases testCase
+      forM_ FunGraph.Test.allTestCases testCase
   where
     traceFunction = if shouldTrace then traceResults else id
 

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -28,24 +28,9 @@ main :: IO ()
 main =
   withTraceArg $ \shouldTrace ->
     FunGraph.withGraphFromFile FunGraph.defaultBuildConfig testDataFileName $ \graph -> do
-      spec <- main' shouldTrace (mkQueryFunctions shouldTrace) graph
+      spec <- main' shouldTrace (FunGraph.Test.mkQueryFunctions shouldTrace) graph
       runHspecWithTraceTip shouldTrace spec
   where
-    mkQueryFunctions shouldTrace = NE.fromList
-      [ ("Stream", FunGraph.Test.queryTreeAndPathsGAStreamTest 1000)
-      , ("List", mkQueryTestList shouldTrace)
-      ]
-
-    mkQueryTestList
-      :: Bool
-      -> FunGraph.Test.Args
-      -> FunGraph.Graph ST.RealWorld
-      -> IO QueryResults
-    mkQueryTestList shouldTrace args graph =
-      let runQueryFunction =
-            if shouldTrace then FunGraph.runGraphActionTrace else FunGraph.runGraphAction
-      in ST.stToIO $ runQueryFunction graph $ FunGraph.Test.queryTreeAndPathsGAListTest args
-
     traceCLIArg :: String
     traceCLIArg = "--trace"
 
@@ -59,12 +44,9 @@ main =
         putStrLn $ "\nTest suite had failures. Run again with the " <> traceCLIArg <> " argument to print tracing information."
       HSpec.evaluateSummary summary
 
-type QueryResults =
-  Either (FunGraph.GraphActionError FunGraph.FullyQualifiedType) [(FunGraph.Test.PPFunctions, Double)]
-
 main'
   :: Bool
-  -> NE.NonEmpty (String, FunGraph.Test.Args -> FunGraph.Graph ST.RealWorld -> IO QueryResults)
+  -> NE.NonEmpty (String, FunGraph.Test.Args -> FunGraph.Graph ST.RealWorld -> IO FunGraph.Test.QueryResults)
   -> FunGraph.Graph ST.RealWorld
   -> IO HSpec.Spec
 main' shouldTrace queryFunctions graph = do

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -59,14 +59,18 @@ main' shouldTrace graph = do
                   FunGraph.Test.queryTest_expectedResult test
             graphEdges `isSupersetOf` ppFunctions
           HSpec.it "contained in top query results" $ do
-            eResult <- ST.stToIO $ runQueryFunction graph $ FunGraph.Test.queryTest_runQuery test
+            let queryTestStream = FunGraph.Test.queryTreeAndPathsGAStreamTest timeout args
+                args = FunGraph.Test.queryTest_args test
+                timeout = 1000
+            eResult <- queryTestStream graph
             result <- either handleError pure eResult
             Set.fromList (map fst $ traceFunction result)
               `isSupersetOf`
                 FunGraph.Test.queryTest_expectedResult test
   pure $ HSpec.describe "Unit tests" $ do
     HSpec.describe "Expected result" $
-      forM_ FunGraph.Test.allTestCases testCase
+      HSpec.describe "Stream" $
+        forM_ FunGraph.Test.allTestCases testCase
   where
     traceFunction = if shouldTrace then traceResults else id
 

--- a/test/web/Spec.hs
+++ b/test/web/Spec.hs
@@ -43,16 +43,18 @@ main = do
   System.IO.Temp.withSystemTempDirectory "haskell-function-graph-test-web" $ \failureReportFileDir -> do
     let failureReportFile = failureReportFileDir <> "/failure.report"
         setConfigFailureReport cfg = cfg{HSpec.configFailureReport = Just failureReportFile}
-    summary <- withSpec Server.defaultSearchConfig
+    summary <- withSpec defaultSearchConfig
       (HSpec.hspecWithResult $ setConfigFailureReport config)
     unless (HSpec.isSuccess summary) $ do
       putStrLn "\nTest suite had failures. Rerunning failed test cases with tracing enabled..."
       let mkRerunConfig cfg =
             cfg{HSpec.configRerun = True, HSpec.configConcurrentJobs = Just 1} -- tracing output is difficult to read if test cases are run in parallel
-      void $ withSpec Server.defaultSearchConfig{Server.searchConfigTrace = Just traceFun}
+      void $ withSpec defaultSearchConfig{Server.searchConfigTrace = Just traceFun}
         (HSpec.hspecWithResult $ mkRerunConfig $ setConfigFailureReport config)
     HSpec.evaluateSummary summary
   where
+    defaultSearchConfig = Server.defaultSearchConfig{Server.searchConfigTimeout = 100}
+
     traceFun str =
       let color color' = concat
             [ ANSI.setSGRCode [ANSI.SetColor ANSI.Background ANSI.Dull color']

--- a/test/web/Spec.hs
+++ b/test/web/Spec.hs
@@ -33,9 +33,6 @@ import qualified System.Environment
 import qualified Test.Hspec.Runner as HSpec
 import Data.Functor (void)
 
-testDataFileName :: FilePath
-testDataFileName = "data/all3.json"
-
 main :: IO ()
 main = do
   config <- System.Environment.getArgs

--- a/test/web/Spec.hs
+++ b/test/web/Spec.hs
@@ -5,7 +5,7 @@
 module Main (main) where
 
 import FunGraph.Test.Util
-import Control.Monad (forM_)
+import Control.Monad (forM_, unless)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -26,17 +26,53 @@ import Data.Maybe (mapMaybe)
 import qualified Data.List.NonEmpty as NE
 import qualified Types
 import qualified Server.Api
+import qualified GHC.IO.Unsafe
+import qualified System.Console.ANSI as ANSI
+import qualified System.IO.Temp
+import qualified System.Environment
+import qualified Test.Hspec.Runner as HSpec
+import Data.Functor (void)
 
 testDataFileName :: FilePath
 testDataFileName = "data/all3.json"
 
 main :: IO ()
-main =
-  Server.withHandlers logger Server.Pages.Search.defaultSearchConfig mempty testDataFileName $ \handlers ->
+main = do
+  config <- System.Environment.getArgs
+    >>= HSpec.readConfig HSpec.defaultConfig
+  System.IO.Temp.withSystemTempDirectory "haskell-function-graph-test-web" $ \failureReportFileDir -> do
+    let failureReportFile = failureReportFileDir <> "/failure.report"
+        setConfigFailureReport cfg = cfg{HSpec.configFailureReport = Just failureReportFile}
+    summary <- withSpec Server.defaultSearchConfig
+      (HSpec.hspecWithResult $ setConfigFailureReport config)
+    unless (HSpec.isSuccess summary) $ do
+      putStrLn "\nTest suite had failures. Rerunning failed test cases with tracing enabled..."
+      let mkRerunConfig cfg =
+            cfg{HSpec.configRerun = True, HSpec.configConcurrentJobs = Just 1} -- tracing output is difficult to read if test cases are run in parallel
+      void $ withSpec Server.defaultSearchConfig{Server.searchConfigTrace = Just traceFun}
+        (HSpec.hspecWithResult $ mkRerunConfig $ setConfigFailureReport config)
+    HSpec.evaluateSummary summary
+  where
+    traceFun str =
+      let color color' = concat
+            [ ANSI.setSGRCode [ANSI.SetColor ANSI.Background ANSI.Dull color']
+            , str
+            , ANSI.setSGRCode [ANSI.Reset]
+            ]
+      in pure $
+        GHC.IO.Unsafe.unsafePerformIO $ do
+          putStrLn $ color ANSI.Red
+
+withSpec
+  :: Server.Pages.Search.SearchConfig
+  -> (HSpec.Spec -> IO a)
+  -> IO a
+withSpec searchConfig f =
+  Server.withHandlers logger searchConfig mempty testDataFileName $ \handlers ->
     runWarpTestRandomPort (Server.app handlers) $ \port -> do
       queryFun <- mkQueryFunction port
       let runQuery = fmap parsePPFunctions <$> queryFun id (Just Server.Api.NoGraph)
-      main' runQuery >>= HSpec.hspec
+      main' runQuery >>= f
   where
     logger = const $ pure ()
 


### PR DESCRIPTION
## Also

* `test-web`: re-run with tracing enabled on failed test cases
* Fail unless we get at least 'maxCount' results

## TODO

- [x] nix-build on macOS 12 fails: https://github.com/runeksvendsen/haskell-function-graph/actions/runs/11194759016/job/31121635582

Fixes #7 (cf. https://github.com/runeksvendsen/haskell-function-graph/pull/6/commits/ea40d8f63a235abfdcece52c75c55dbc3a1d60d1)