### PR TITLE
Make destination type optional

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -64,7 +64,7 @@ main = do
     vertices <- ST.stToIO $ DG.vertexLabels graph
     forM_ vertices $ \src ->
       forM_ vertices $ \dst -> do
-        res <- query timoutMillis graph src dst
+        res <- query timoutMillis graph src (Just dst)
         case res of
           [] -> pure ()
           (fns,_):_ -> when (length fns > 9) $ do

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/runeksvendsen/bellman-ford.git
-    tag: ef7c86f36b13d109f58b70946e023fa83502dec8
+    tag: 9a511144d46f07ff0e3632120b7d6eecf1491814
 
 source-repository-package
     type: git

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
   bellman-ford =
     let src = builtins.fetchGit {
       url = "https://github.com/runeksvendsen/bellman-ford.git";
-      rev = "ef7c86f36b13d109f58b70946e023fa83502dec8";
+      rev = "9a511144d46f07ff0e3632120b7d6eecf1491814";
     };
     in import src { inherit nixpkgs compiler; };
 

--- a/function-graph.cabal
+++ b/function-graph.cabal
@@ -80,6 +80,7 @@ library function-graph-server
                     , time
                     , file-embed
                     , these
+                    , dump-decls-lib
     hs-source-dirs:   src/server
     default-language: Haskell2010
 

--- a/src/lib/FunGraph/Types.hs
+++ b/src/lib/FunGraph/Types.hs
@@ -13,6 +13,8 @@ module FunGraph.Types
   , functionPackageNoVersion, renderFunctionPackage
   , renderComposedFunctions
   , renderComposedFunctionsStr
+  , retComposedFunctions
+  , argComposedFunctions
   , parseComposedFunctions, parseComposedFunctionsNoPackage
   , renderFunction, renderFunctionNoPackage, functionToHackageDocsUrl
   , typedFunctionFromToTypes
@@ -38,7 +40,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Control.DeepSeq (NFData)
 import qualified Types
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import GHC.Stack (HasCallStack)
 import qualified Data.Hashable.Generic
 
@@ -71,6 +73,20 @@ renderFunctionPackage
   -> T.Text
 renderFunctionPackage =
   Types.renderFgPackage . _function_package
+
+-- | Return type of composed functions.
+--
+-- Function list is in order of application, e.g. @g . f@ is @[f, g]@.
+retComposedFunctions :: [TypedFunction] -> Maybe FullyQualifiedType
+retComposedFunctions =
+  fmap (Json.functionType_ret . _function_typeSig) . listToMaybe . reverse
+
+-- | Argument type of composed functions.
+--
+-- Function list is in order of application, e.g. @g . f@ is @[f, g]@.
+argComposedFunctions :: [TypedFunction] -> Maybe FullyQualifiedType
+argComposedFunctions =
+  fmap (Json.functionType_arg . _function_typeSig) . listToMaybe
 
 -- | Render composed functions.
 --

--- a/src/server/Server/Pages/Root.hs
+++ b/src/server/Server/Pages/Root.hs
@@ -106,15 +106,14 @@ mkTypeaheadInputs
 mkTypeaheadInputs initialSuggestions (mSrc, mDst) = do
   script_ $ "function " <> jsTriggerFunctionName <> "(event) { return event instanceof KeyboardEvent }"
   pure
-    ( mkInput' "src" mSrc
-    , mkInput' "dst" mDst
+    ( mkInput' [required_ ""] "src" mSrc
+    , mkInput' [] "dst" mDst
     )
   where
-    mkInput' = mkInput jsTriggerFunctionName attrs initialSuggestions
+    mkInput' attrs = mkInput jsTriggerFunctionName (placeholderAttr : attrs) initialSuggestions
 
-    attrs =
-      [ placeholder_ "enter an unqualified type name, e.g. Text, and select the qualified name above"
-      ]
+    placeholderAttr =
+      placeholder_ "enter an unqualified type name, e.g. Text, and select the qualified name above"
 
     jsTriggerFunctionName = "checkUserKeydown"
 
@@ -139,7 +138,6 @@ mkInput jsTriggerFunctionName attrs initialSuggestions id' mInitialValue = do
     , hxPushUrl_ "false"
     , autocomplete_ "off"
     , spellcheck_ "off"
-    , required_ ""
     , autofocus_
     ]
   where

--- a/src/test/FunGraph/Test.hs
+++ b/src/test/FunGraph/Test.hs
@@ -39,7 +39,7 @@ data QueryTest = QueryTest
     , queryTest_expectedResult :: Set.Set PPFunctions
     }
 
-type Args = (Int, (FunGraph.FullyQualifiedType, FunGraph.FullyQualifiedType)) -- ^ (maxCount, (src, dst))
+type Args = (Int, (FunGraph.FullyQualifiedType, Maybe FunGraph.FullyQualifiedType)) -- ^ (maxCount, (src, dst))
 
 -- | Test 'FunGraph.queryTreeAndPathsGA'
 queryTreeAndPathsGAListTest
@@ -58,7 +58,7 @@ mkTestCase
 mkTestCase maxCount (from, to) expectedList =
     QueryTest
         { queryTest_name = unwords [snd from, "to", snd to]
-        , queryTest_args = (maxCount, (fst from, fst to))
+        , queryTest_args = (maxCount, (fst from, Just $ fst to))
         , queryTest_expectedResult = Set.fromList $ fns expectedList
         }
   where

--- a/src/test/FunGraph/Test/Util.hs
+++ b/src/test/FunGraph/Test/Util.hs
@@ -105,7 +105,7 @@ mkQueryFunction port = do
             htmlStreamToStream
             Nothing -- TODO: also bench 'HX-Boosted'?
             (Just $ FunGraph.renderFullyQualifiedType src)
-            (Just $ FunGraph.renderFullyQualifiedType dst)
+            (FunGraph.renderFullyQualifiedType <$> dst)
             (Just $ fromIntegral maxCount)
             mNoGraph
       in Servant.Client.Streaming.runClientM clientM clientEnv >>= either Ex.throwIO pure


### PR DESCRIPTION
Because it's useful to be able to enumerate all the types reachable from some source type